### PR TITLE
Fix page word count

### DIFF
--- a/content/tabletop-games/_content.gotmpl
+++ b/content/tabletop-games/_content.gotmpl
@@ -8,7 +8,7 @@
   {{ else }}
     {{ $content := dict
       "mediaType" "text/markdown"
-      "value" ""
+      "value" "{{< tabletop-game-description >}}"
     }}
     {{ $params := dict
       "gameInfo" (dict

--- a/layouts/shortcodes/tabletop-game-description.html
+++ b/layouts/shortcodes/tabletop-game-description.html
@@ -1,0 +1,2 @@
+{{- $gameInfo := partial "get-game-info.html" .Page -}}
+{{- $gameInfo.Description | markdownify }}

--- a/layouts/tabletop-games/single.html
+++ b/layouts/tabletop-games/single.html
@@ -25,7 +25,6 @@
     <div class="col col-md-8">
       <h1 class="d-none d-sm-block">{{ .Title }}</h1>
       {{ if .Draft }}<span class="mb-2 mt-2 mt-sm-0 badge text-bg-warning">Draft</span>{{ end }}
-      <div class="pt-3 pt-sm-0">{{ $gameInfo.description | markdownify }}</div>
       <div class="pt-3">{{ .Content }}</div>
     </div>
   </div>


### PR DESCRIPTION
In order to have the game description be considered in the word count (and related properties), it must be added to content. To avoid needing to request game info in the content adaptor, a shortcode is added for injecting the game description. This shortcode is then used as the content for generated game pages.